### PR TITLE
Upgrading to v2.3.9

### DIFF
--- a/plugins/adminControl.php
+++ b/plugins/adminControl.php
@@ -26,7 +26,7 @@ $removeSettings = $module->getUrl("plugins/removeSettings.php", $noAuth = false,
 <hr>
 
 <?php
-if($_GET['note']==1){
+if(array_key_exists('note', $_GET) && $_GET['note']==1){
     ?>
     <div id="actionMsg" class="green" style="max-width: 800px; padding: 15px 25px; margin: 20px 0px; text-align: left; display: none;">
         <span>Request successfully completed</span>

--- a/plugins/saveSettings.php
+++ b/plugins/saveSettings.php
@@ -24,9 +24,30 @@ $module->setLAAPIURL($selectedRegion);
 $module->setLA_PWD($selectedRegion);
 $module->setLA_SSO_ENTITY_ID($selectedRegion);
 
-$accountInfoURL = $module->user_account_info($userInfo[USERID]['userEmail'],$userInfo[USERID]['appPass']);
+$akid = $module->getLAAKID();
+$endpoint = "user_access_info";
+$time = strtotime(date('Y-m-d H:i:s', strtotime(' +5 minutes ')));
+$time = $time * 1000;
 
-$xml = simplexml_load_string(trim($module->curlShell('GET', $accountInfoURL)), "SimpleXMLElement", LIBXML_NOCDATA);
+$key = $module->getLA_PWD(); // <<-- Add the MGB Password here This is the MGB / Partners Lab Archvies PWD
+
+$user = $userInfo[USERID]['userEmail']; // <<--- Add your Email here
+$user_token = $userInfo[USERID]['appPass']; // <<-- ADD YOUR Token HERE
+
+$sha512_value = hash_hmac("sha512", $akid.$endpoint.$time, $key, true);
+$base64 = base64_encode($sha512_value);;
+
+$params = [
+    "login_or_email"    => $user,
+    "password"          => $user_token,
+    "akid"              => $akid,
+    "expires"           => $time,
+    "sig"               => $base64
+];
+
+$url = "https://api.labarchives.com/api/users/user_access_info?".http_build_query($params);
+
+$xml = simplexml_load_string(trim($module->curlShell('GET', $url)), "SimpleXMLElement", LIBXML_NOCDATA);
 
 $UI=$xml->id[0];
 

--- a/plugins/transfer.php
+++ b/plugins/transfer.php
@@ -56,7 +56,7 @@ if(!empty($nbid)){
 
     if($targetFolderExists){
 
-            $module->addRECapFolderOrPageToNotebook($userUID, $nbid, $parent_tree_id, $call_type = "notebook", "false", $pageName);
+            $module->addRECapFolderOrPageToNotebook($userUID, $nbid, "false", $pageName, $parent_tree_id, $call_type = "notebook");
             // Get the page id (which is used for parent_tree_id or pid) of the newly create page in the REDCap Folder
             // Unfortunately, the page id is not returned on the LA API call that creates it and must be found by
             // parsing the existing notebook tree.
@@ -76,7 +76,7 @@ if(!empty($nbid)){
                     $pid = $noteBookFolders2["level-nodes"]["level-node"]["tree-id"];
                     $expires = number_format(microtime(true) * 1000, 0, "", "");
                     $sig = $module->build_signature("add_attachment", $expires, "notebook");
-                    $module->labArcAddAttachment($userUID, $filename, $module->LA_AKID, $caption, $nbid, $pid, $expires, $sig);
+                    $module->labArcAddAttachment($userUID, $filename, $module->LA_AKID, $caption, $expires, $sig, $nbid, $pid);
 
                 }
                 return;
@@ -92,7 +92,7 @@ if(!empty($nbid)){
                         $pid = $nbDetails["tree-id"];
                         $expires = number_format(microtime(true)*1000,0,"","");
                         $sig= $module->build_signature("add_attachment", $expires, "notebook");
-                        $module->labArcAddAttachment($userUID, $filename, $module->LA_AKID, $caption, $nbid, $pid, $expires, $sig);
+                        $module->labArcAddAttachment($userUID, $filename, $module->LA_AKID, $caption, $expires, $sig, $nbid, $pid);
 
                     }
 
@@ -102,7 +102,7 @@ if(!empty($nbid)){
     } else {
         // If it doesn't, then create it then attach the report
 
-        $addResponse = $module->addRECapFolderOrPageToNotebook($userUID,$nbid,$parent_tree_id = 0,$call_type = "notebook", "true","REDCap");
+        $addResponse = $module->addRECapFolderOrPageToNotebook($userUID,$nbid,"true","REDCap", $parent_tree_id = 0,$call_type = "notebook");
         // Get the folder id (which is used for parent_tree_id) of the newly create REDCap folder
         // Unfortunately, the folder id is not returned on the LA API call that creates it and must be found by
         // parsing the existing notebook tree.
@@ -119,7 +119,7 @@ if(!empty($nbid)){
         if($newFolderExists) {
             // if REDCap folder exists in the Notebook, then add a new page, under the REDCap folder, to host the incoming report.
 
-            $module->addRECapFolderOrPageToNotebook($userUID, $nbid, $parent_tree_id, $call_type = "notebook", "false", $pageName);
+            $module->addRECapFolderOrPageToNotebook($userUID, $nbid, "false", $pageName, $parent_tree_id, $call_type = "notebook");
             // Get the page id (which is used for parent_tree_id or pid) of the newly create page in the REDCap Folder
             // Unfortunately, the page id is not returned on the LA API call that creates it and must be found by
             // parsing the existing notebook tree.
@@ -140,7 +140,7 @@ if(!empty($nbid)){
                     $pid = $noteBookFolders2["level-nodes"]["level-node"]["tree-id"];
                     $expires = number_format(microtime(true) * 1000, 0, "", "");
                     $sig = $module->build_signature("add_attachment", $expires, "notebook");
-                    $module->labArcAddAttachment($userUID, $filename, $module->LA_AKID, $caption, $nbid, $pid, $expires, $sig);
+                    $module->labArcAddAttachment($userUID, $filename, $module->LA_AKID, $caption, $expires, $sig, $nbid, $pid);
 
                 }
                 return;
@@ -157,7 +157,7 @@ if(!empty($nbid)){
                             $pid = $nbDetails["tree-id"];
                             $expires = number_format(microtime(true)*1000,0,"","");
                             $sig= $module->build_signature("add_attachment", $expires, "notebook");
-                            $module->labArcAddAttachment($userUID, $filename, $module->LA_AKID, $caption, $nbid, $pid, $expires, $sig);
+                            $module->labArcAddAttachment($userUID, $filename, $module->LA_AKID, $caption, $expires, $sig, $nbid, $pid);
 
                         }
 

--- a/uploadToLabarchives.php
+++ b/uploadToLabarchives.php
@@ -128,7 +128,8 @@ class uploadToLabarchives extends \ExternalModules\AbstractExternalModule
 
         $cssFile = $this->getUrl("css/laModal.css", $noAuth = false, $useApiEndpoint = false);
 
-        if (strlen(strstr(PAGE,"DataExport/index.php")) > 0
+        if ($this-> isSessionCurrent()
+            and strlen(strstr(PAGE,"DataExport/index.php")) > 0
             and $_GET['pid'] == $project_id
             and !is_null( htmlspecialchars($_GET['report_id'],ENT_QUOTES) )){
 
@@ -136,7 +137,11 @@ class uploadToLabarchives extends \ExternalModules\AbstractExternalModule
 
             $modalContent = $this->minifier($this->modalContent($project_id));
 
-            $autoOpenModal = $_GET['s'] == 1 && is_null($_GET['t']) ? '' : 'closed';
+            $autoOpenModal = 'closed';
+            if(array_key_exists('s',$_GET) && array_key_exists('t',$_GET)){
+                $autoOpenModal = $_GET['s'] == 1 && is_null($_GET['t']) ? '' : 'closed';
+            }
+
 
             $scriptExport = <<<SCRIPT
 <script type="text/javascript"> 
@@ -191,7 +196,7 @@ openButton.addEventListener("click", function() {
 SCRIPT;
             print $scriptExport;
 
-            if($_GET['t']==2){
+            if(array_key_exists('t', $_GET) && $_GET['t']==2){
                 $this->successfulTransfer();
             }
         }
@@ -477,7 +482,8 @@ SCRIPT;
         $json = json_encode($xml);
         $array = json_decode($json,TRUE);
 
-        if(!is_null($array["level-nodes"]["level-node"][0])) {
+        if(array_key_exists(0, $array["level-nodes"]["level-node"]) &&
+            !is_null($array["level-nodes"]["level-node"][0])) {
             foreach ($array["level-nodes"]["level-node"] as $k => $v) {
                 if ($v["is-page"] == "false" && $v["user-access"]["can-write"] == "true") {
                     $folderList[$k] = array("id" => $v["tree-id"], "name" => $v["display-text"]);
@@ -514,7 +520,7 @@ SCRIPT;
 
     }
 
-    function labArcAddAttachment($uid, $filename, $akid, $caption, $nbid = '', $pid = '', $expires, $sig){
+    function labArcAddAttachment($uid, $filename, $akid, $caption, $expires, $sig, $nbid = '', $pid = ''){
         $fileContent =file_get_contents(APP_PATH_TEMP . $filename);
         $la_api_url = $this->getLAAPIURL();
         if($nbid != '' && $pid != ''){
@@ -544,7 +550,7 @@ SCRIPT;
         curl_close($curl);
     }
 
-    function addRECapFolderOrPageToNotebook($uid,$nbid,$parent_tree_id = 0,$call_type = "notebook",$is_folder,$display_text){
+    function addRECapFolderOrPageToNotebook($uid,$nbid,$is_folder,$display_text,$parent_tree_id = 0,$call_type = "notebook"){
         $api_class = "tree_tools";
         $api_call = "insert_node";
         $email = NULL;
@@ -604,8 +610,15 @@ SCRIPT;
     }
 
     function modalContent($project_id){
-        $userInfo =json_decode(stripslashes($this->getSystemSetting(USERID)), TRUE);
-        $userUID = $this->decrypt_config_string($userInfo[USERID]['UID']);
+        global $user_rights;
+        
+        if(!is_null($this->getSystemSetting($user_rights["username"]))){
+            $userInfo =json_decode(stripslashes($this->getSystemSetting($user_rights["username"])), TRUE);
+            $userUID = $this->decrypt_config_string($userInfo[$user_rights["username"]]['UID']);
+        } else {
+            $userInfo = NULL;
+            $userUID = '';
+        }
 
         $noticeLanguage = "<div style=\'bottom: -10px;position: relative;\'>
         <div class=\'notice\'>
@@ -647,8 +660,8 @@ SCRIPT;
 
         // UI for Basic Account Setup
         if(is_null($userInfo) || $userUID == "") {
-            $email = $userInfo[USERID]['userEmail'];
-            $pass = $userInfo[USERID]['appPas'];
+            $email = ''; //$email = $userInfo[USERID]['userEmail'];
+            $pass = '' ; //$pass = $userInfo[USERID]['appPas'];
             $RegionSelect = $this->dropdownMenu('regionSelect', $this->getRegionList(), 'Select Region: ');;
             $setup = "<div class=\'modal-guts\'>    <div>		
         Setup a link to your LabArchives account. Follow the steps below:</div> <hr><p>
@@ -686,7 +699,7 @@ SCRIPT;
             $saveLink = $this->getUrl("plugins/saveSettings.php", $noAuth = false, $useApiEndpoint = false);
             $removeSettings = $this->getUrl("plugins/removeSettings.php", $noAuth = false, $useApiEndpoint = false);
 
-            $tempID = USERID;
+            $tempID = $user_rights["username"];
             $linkScript = <<<SCRIPT
 <script>
 function linkNow(){
@@ -768,14 +781,14 @@ SCRIPT;
             return $setup;
         } else {
             //
-            $selectedRegion = $userInfo[USERID]['region'];
+            $selectedRegion = $userInfo[$user_rights["username"]]['region'];
             // Set required variables
             $this->setLAAPIURL($selectedRegion);
             $this->setLAAKID($selectedRegion);
             $this->setLA_SSO_ENTITY_ID($selectedRegion);
             $this->setLA_PWD($selectedRegion);
 
-            $notebookURL = $this->get_notebook_list($userUID,$userInfo[USERID]['userEmail']);
+            $notebookURL = $this->get_notebook_list($userUID,$userInfo[$user_rights["username"]]['userEmail']);
 
             $xml = simplexml_load_string(trim($this->curlShell('GET', $notebookURL)), "SimpleXMLElement", LIBXML_NOCDATA);
 
@@ -798,7 +811,7 @@ SCRIPT;
 
             $transferLink = $this->getUrl("plugins/transfer.php", $noAuth = false, $useApiEndpoint = false);
             $removeSettings = $this->getUrl("plugins/removeSettings.php", $noAuth = false, $useApiEndpoint = false);
-            $tempID = USERID;
+            $tempID = $user_rights["username"];
 
             $transferScript = <<<SCRIPT
 <script type="text/javascript">   
@@ -960,5 +973,13 @@ SCRIPT;
 
         curl_close($curl);
         return $response;
+    }
+
+    function isSessionCurrent(){
+        if(session_status() == PHP_SESSION_ACTIVE){
+            return true;
+        } else {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Bug Fix: A change in the REDCap core code mistakenly removed the button for uploading reports to Lab Archives. The external module was using a check for determining the authentication status and displaying the upload button. It was checking a global variable that REDCap is no longer using on REDCap v15.0.25 LTS, and thus, its check was failing. The method being used for this purpose was modified to use a PHP function session_status and it successfully fixed the issue. The button for uploading reports to Lab Archives is now available on the report page, as expected.